### PR TITLE
reconnect for each mail

### DIFF
--- a/gomailer/gomail.go
+++ b/gomailer/gomail.go
@@ -12,7 +12,7 @@ type Sender struct {
 
 // Config gomail config
 type Config struct {
-	Sender gomail.Sender
+	Dialer *gomail.Dialer
 }
 
 // New initalize gomail sender with gomail.Dailer
@@ -85,5 +85,5 @@ func (sender *Sender) Send(email mailer.Email) error {
 		}
 	}
 
-	return gomail.Send(sender.Sender, m)
+	return sender.Dialer.DialAndSend(m)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -20,7 +20,7 @@ type Sender struct {
 
 // Config gomail config
 type Config struct {
-	output io.Writer
+	Output io.Writer
 }
 
 // New initalize gomail sender with gomail.Dailer
@@ -29,8 +29,8 @@ func New(config *Config) *Sender {
 		config = &Config{}
 	}
 
-	if config.output == nil {
-		config.output = os.Stderr
+	if config.Output == nil {
+		config.Output = os.Stderr
 	}
 
 	return &Sender{Config: config}
@@ -93,6 +93,6 @@ func (sender *Sender) Send(email mailer.Email) error {
 	}
 
 	sender.Sent = append(sender.Sent, &email)
-	_, err := io.Copy(sender.output, result)
+	_, err := io.Copy(sender.Output, result)
 	return err
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/qor/mailer"
-	gomail "gopkg.in/gomail.v2"
 )
 
 // Sender gomail struct
@@ -16,9 +15,7 @@ type Sender struct {
 }
 
 // Config gomail config
-type Config struct {
-	Sender gomail.Sender
-}
+type Config struct{}
 
 // New initalize gomail sender with gomail.Dailer
 func New(config *Config) *Sender {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,7 +3,9 @@ package logger
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/mail"
+	"os"
 	"strings"
 
 	"github.com/qor/mailer"
@@ -15,12 +17,18 @@ type Sender struct {
 }
 
 // Config gomail config
-type Config struct{}
+type Config struct {
+	output io.Writer
+}
 
 // New initalize gomail sender with gomail.Dailer
 func New(config *Config) *Sender {
 	if config == nil {
 		config = &Config{}
+	}
+
+	if config.output == nil {
+		config.output = os.Stderr
 	}
 
 	return &Sender{Config: config}
@@ -82,6 +90,6 @@ func (sender *Sender) Send(email mailer.Email) error {
 		fmt.Fprintf(result, "\nContent-Type: text/html; charset=UTF-8\n%v\n", email.HTML)
 	}
 
-	fmt.Println(result.String())
-	return nil
+	_, err := io.Copy(sender.output, result)
+	return err
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -28,19 +28,19 @@ func New(config *Config) *Sender {
 
 // Send send email with GoMail
 func (sender *Sender) Send(email mailer.Email) error {
-	var result bytes.Buffer
+	var result = new(bytes.Buffer)
 
 	formatAddress := func(key string, addresses []mail.Address) {
 		var emails []string
 
 		if len(addresses) > 0 {
-			result.WriteString(fmt.Sprintf("%v: ", key))
+			fmt.Fprintf(result, "%v: ", key)
 
 			for _, address := range addresses {
 				emails = append(emails, address.String())
 			}
 
-			result.WriteString(strings.Join(emails, ", ") + "\n")
+			fmt.Fprintf(result, "%s\n", strings.Join(emails, ", "))
 		}
 	}
 
@@ -57,29 +57,29 @@ func (sender *Sender) Send(email mailer.Email) error {
 	}
 
 	if email.Subject != "" {
-		result.WriteString(fmt.Sprintf("Subject: %v\n", email.Subject))
+		fmt.Fprintf(result, "Subject: %v\n", email.Subject)
 	}
 
 	if email.Headers != nil {
 		for key, value := range email.Headers {
-			result.WriteString(fmt.Sprintf("%v: %v\n", key, value))
+			fmt.Fprintf(result, "%v: %v\n", key, value)
 		}
 	}
 
 	for _, attachment := range email.Attachments {
 		if attachment.Inline {
-			result.WriteString(fmt.Sprintf("\nContent-Disposition: inline; filename=\"%v\"\n\n", attachment.FileName))
+			fmt.Fprintf(result, "\nContent-Disposition: inline; filename=\"%v\"\n\n", attachment.FileName)
 		} else {
-			result.WriteString(fmt.Sprintf("\nContent-Disposition: attachment; filename=\"%v\"\n\n", attachment.FileName))
+			fmt.Fprintf(result, "\nContent-Disposition: attachment; filename=\"%v\"\n\n", attachment.FileName)
 		}
 	}
 
 	if email.Text != "" {
-		result.WriteString(fmt.Sprintf("\nContent-Type: text/plain; charset=UTF-8\n%v\n", email.Text))
+		fmt.Fprintf(result, "\nContent-Type: text/plain; charset=UTF-8\n%v\n", email.Text)
 	}
 
 	if email.HTML != "" {
-		result.WriteString(fmt.Sprintf("\nContent-Type: text/html; charset=UTF-8\n%v\n", email.HTML))
+		fmt.Fprintf(result, "\nContent-Type: text/html; charset=UTF-8\n%v\n", email.HTML)
 	}
 
 	fmt.Println(result.String())

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -14,6 +14,8 @@ import (
 // Sender gomail struct
 type Sender struct {
 	*Config
+
+	Sent []*mailer.Email
 }
 
 // Config gomail config
@@ -90,6 +92,7 @@ func (sender *Sender) Send(email mailer.Email) error {
 		fmt.Fprintf(result, "\nContent-Type: text/html; charset=UTF-8\n%v\n", email.HTML)
 	}
 
+	sender.Sent = append(sender.Sent, &email)
 	_, err := io.Copy(sender.output, result)
 	return err
 }


### PR DESCRIPTION
With the `sender` dialing once in the config, the dialed connection might get closed at any time leading to the following error when qor tries to use it later.

`gomail: could not send email 1: write tcp $from->$to: write: broken pipe`

A better approach for high load might be keep the sender and use a _ping_-like smtp command before sending an email and re-dial then on error.